### PR TITLE
Implement rendering of .increments()

### DIFF
--- a/src/backend/mssql.rs
+++ b/src/backend/mssql.rs
@@ -105,6 +105,11 @@ impl SqlGenerator for MsSql {
             ),
         };
 
+        let increment = match tt.increments {
+            true => " IDENTITY(1,1)",
+            false => "",
+        };
+
         let primary_key_indicator = match tt.primary {
             true => " PRIMARY KEY",
             false => "",
@@ -126,9 +131,11 @@ impl SqlGenerator for MsSql {
         };
 
         format!(
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}",
             // `ADD name VARCHAR(max)` or `name VARCHAR(max)`
             name_and_type,
+            // `IDENTITY(1,1)` or nothing
+            increment,
             // `PRIMARY KEY` or nothing
             primary_key_indicator,
             // `DEFAULT 'foo'` or nothing

--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -53,7 +53,7 @@ impl SqlGenerator for MySql {
 
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}",
             match bt {
                 Text => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
                 Varchar(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
@@ -75,6 +75,10 @@ impl SqlGenerator for MySql {
                 Array(it) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(Array(Box::new(*it)), schema)),
                 Index(_) => unreachable!("Indices are handled via custom builder"),
                 Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
+            },
+            match tt.increments {
+                true => " AUTO_INCREMENT",
+                false => "",
             },
             match tt.primary {
                 true => " PRIMARY KEY",

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -61,6 +61,7 @@ impl SqlGenerator for Pg {
                 Varchar(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
                 Char(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
                 Primary => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
+                Integer if tt.increments => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(Serial, schema)),
                 Integer => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
                 Serial => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
                 Float => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -51,7 +51,7 @@ impl SqlGenerator for Sqlite {
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
             // SQL base - default - nullable - unique
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}",
             match bt {
                 Text => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Varchar(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
@@ -78,6 +78,11 @@ impl SqlGenerator for Sqlite {
                 true => " PRIMARY KEY",
                 false => "",
             },
+            match tt.increments {
+                true => " AUTOINCREMENT",
+                false => "",
+            },
+
             match (&tt.default).as_ref() {
                 Some(ref m) => match m {
                     WrappedDefault::Function(ref fun) => match fun {

--- a/src/tests/common/runtime.rs
+++ b/src/tests/common/runtime.rs
@@ -16,4 +16,5 @@ fn generate_from() {
     let _ = m.make_from(SqlVariant::Pg);
     let _ = m.make_from(SqlVariant::Mysql);
     let _ = m.make_from(SqlVariant::Sqlite);
+    let _ = m.make_from(SqlVariant::Mssql);
 }

--- a/src/tests/mssql/create_table.rs
+++ b/src/tests/mssql/create_table.rs
@@ -147,3 +147,18 @@ fn foreign_key_constraint() {
         )
     );
 }
+
+#[test]
+fn auto_increment() {
+    let mut m = Migration::new();
+    m.create_table("users", |t: &mut Table| {
+        t.add_column("id", types::integer().increments(true).primary(true));
+    });
+
+    assert_eq!(
+        m.make::<MsSql>(),
+        String::from(
+            r#"CREATE TABLE [users] ([id] INT IDENTITY(1,1) PRIMARY KEY NOT NULL);"#
+        )
+    );
+}

--- a/src/tests/mysql/create_table.rs
+++ b/src/tests/mysql/create_table.rs
@@ -87,3 +87,19 @@ fn foreign_key_constraint() {
         )
     );
 }
+
+#[test]
+fn auto_increment() {
+    let mut m = Migration::new();
+    m.create_table("users", |t: &mut Table| {
+        t.add_column("id", types::integer().increments(true).primary(true));
+
+    });
+
+    assert_eq!(
+        m.make::<MySql>(),
+        String::from(
+            r#"CREATE TABLE `users` (`id` INTEGER AUTO_INCREMENT PRIMARY KEY NOT NULL);"#
+        )
+    );
+}

--- a/src/tests/pg/create_table.rs
+++ b/src/tests/pg/create_table.rs
@@ -180,3 +180,19 @@ fn rename_table() {
         String::from("ALTER TABLE \"users\" RENAME TO \"cool_users\";")
     );
 }
+
+#[test]
+fn auto_increment() {
+    let mut m = Migration::new();
+    m.create_table("users", |t: &mut Table| {
+        t.add_column("id", types::integer().increments(true).nullable(false));
+        t.set_primary_key(&["id"])
+    });
+
+    assert_eq!(
+        m.make::<Pg>(),
+        String::from(
+            r#"CREATE TABLE "users" ("id" SERIAL NOT NULL, PRIMARY KEY ("id"));"#
+        )
+    );
+}

--- a/src/tests/sqlite3/create_table.rs
+++ b/src/tests/sqlite3/create_table.rs
@@ -83,3 +83,19 @@ fn foreign_key_constraint() {
         )
     );
 }
+
+#[test]
+fn auto_increment() {
+    let mut m = Migration::new();
+    m.create_table("users", |t: &mut Table| {
+        t.add_column("id", types::integer().increments(true).nullable(false));
+       t.set_primary_key(&["id"])
+    });
+
+    assert_eq!(
+        m.make::<Sqlite>(),
+        String::from(
+            r#"CREATE TABLE "users" ("id" INTEGER AUTOINCREMENT NOT NULL, PRIMARY KEY ("id"));"#
+        )
+    );
+}

--- a/src/types/builders.rs
+++ b/src/types/builders.rs
@@ -13,7 +13,7 @@ use crate::types::Type;
 pub fn primary() -> Type {
     Type::new(BaseType::Primary)
         .nullable(true) // Primary keys are non-null implicitly
-        .increments(true) // This is ignored for now
+        .increments(false) // Primary keys are auto-increment implicitly
         .primary(false) // Primary keys are primary implictly
         .unique(false) // Primary keys are unique implicitly
         .indexed(false)


### PR DESCRIPTION
increments was silently ignored, we need it now  since sqlite int primary keys are always autoincrement by default. since we need to name mssql primaries we now need to write:

t.add_column("id", types::integer().increments(true).nullable(false))
t.add_constraint("name", types::primary_key(&["id"]))

instead of
t.add_column("id", types::primary())

and still have it come out as id Int @default(autoincrement())